### PR TITLE
fix: remove bintray from repositories

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,10 +55,6 @@ repositories {
   jcenter()
   google()
 
-  maven {
-    url 'https://dl.bintray.com/crispim/crisp-maven'
-  }
-
   def found = false
   def defaultDir = null
   def androidSourcesName = 'React Native sources'


### PR DESCRIPTION
Hi,

bintray is not reliable (see #48 and #47) and now crisp sdk is available on maven central : https://search.maven.org/artifact/im.crisp/crisp-sdk/1.0.7/aar

So we should be able to remove bintray