### PR TITLE
fix: incorrect path for typescript definition file

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,4 @@
-
 {
   "extends": "./tsconfig",
-  "exclude": ["example"]
+  "exclude": ["example", "plugin"]
 }


### PR DESCRIPTION
https://github.com/walterholohan/react-native-crisp-chat-sdk/pull/76 leads to a regression in build of index.d.ts files 

Instead of being under `typescript` directory, since 0.11.0 it is under `plugin/src` directory (and so typescript does not find it) 




