### PR TITLE
feat/configure-method add: Crisp configure method

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ displayed in english. If `localeIdentifier: fr_FR` appears in your Xcode logs, i
 - `CrispChatSDK.setSessionBool('key', 'value')`
 - `CrispChatSDK.setSessionInt('key', 'value')`
 - `CrispChatSDK.resetSession()`
+- `CrispChatSDK.configure('YOUR_WEBSITE_ID')`
 
 ## Contributing
 

--- a/android/src/main/java/com/reactnativecrispchatsdk/CrispChatSdkModule.kt
+++ b/android/src/main/java/com/reactnativecrispchatsdk/CrispChatSdkModule.kt
@@ -98,4 +98,10 @@ class CrispChatSdkModule(reactContext: ReactApplicationContext) : ReactContextBa
         crispIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         context.startActivity(crispIntent)
     }
+
+    @ReactMethod
+    fun configure(websiteID: String) {
+        val context = reactApplicationContext
+        Crisp.configure(context, websiteID)
+    }
 }

--- a/android/src/main/java/com/reactnativecrispchatsdk/CrispChatSdkModule.kt
+++ b/android/src/main/java/com/reactnativecrispchatsdk/CrispChatSdkModule.kt
@@ -100,8 +100,8 @@ class CrispChatSdkModule(reactContext: ReactApplicationContext) : ReactContextBa
     }
 
     @ReactMethod
-    fun configure(websiteID: String) {
+    fun configure(websiteId: String) {
         val context = reactApplicationContext
-        Crisp.configure(context, websiteID)
+        Crisp.configure(context, websiteId)
     }
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - boost-for-react-native (1.63.0)
   - CocoaAsyncSocket (7.6.5)
-  - Crisp (1.6.1)
+  - Crisp (2.2.1)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.64.1)
   - FBReactNativeSpec (0.64.1):
@@ -254,7 +254,7 @@ PODS:
     - React-perflogger (= 0.64.1)
   - React-jsinspector (0.64.1)
   - react-native-crisp-chat-sdk (0.10.2):
-    - Crisp (= 1.6.1)
+    - Crisp (= 2.2.1)
     - React
   - React-perflogger (0.64.1)
   - React-RCTActionSheet (0.64.1):

--- a/ios/CrispChatSdk.m
+++ b/ios/CrispChatSdk.m
@@ -14,6 +14,6 @@ RCT_EXTERN_METHOD(setSessionInt:(NSString *)key value:(int)value)
 RCT_EXTERN_METHOD(pushSessionEvent:(NSString *)eventName color:(NSInteger *)color)
 RCT_EXTERN_METHOD(resetSession)
 RCT_EXTERN_METHOD(show)
-RCT_EXTERN_METHOD(configure:(NSString *)websiteID)
+RCT_EXTERN_METHOD(configure:(NSString *)websiteId)
 
 @end

--- a/ios/CrispChatSdk.m
+++ b/ios/CrispChatSdk.m
@@ -14,5 +14,6 @@ RCT_EXTERN_METHOD(setSessionInt:(NSString *)key value:(int)value)
 RCT_EXTERN_METHOD(pushSessionEvent:(NSString *)eventName color:(NSInteger *)color)
 RCT_EXTERN_METHOD(resetSession)
 RCT_EXTERN_METHOD(show)
+RCT_EXTERN_METHOD(configure:(NSString *)websiteId)
 
 @end

--- a/ios/CrispChatSdk.m
+++ b/ios/CrispChatSdk.m
@@ -14,6 +14,6 @@ RCT_EXTERN_METHOD(setSessionInt:(NSString *)key value:(int)value)
 RCT_EXTERN_METHOD(pushSessionEvent:(NSString *)eventName color:(NSInteger *)color)
 RCT_EXTERN_METHOD(resetSession)
 RCT_EXTERN_METHOD(show)
-RCT_EXTERN_METHOD(configure:(NSString *)websiteId)
+RCT_EXTERN_METHOD(configure:(NSString *)websiteID)
 
 @end

--- a/ios/CrispChatSdk.swift
+++ b/ios/CrispChatSdk.swift
@@ -76,7 +76,7 @@ class CrispChatSdk: NSObject {
     }
 
     @objc
-    static func configure(_ websiteId: String) -> Bool {
+    func configure(_ websiteId: String) -> Bool {
         CrispSDK.configure(websiteID: websiteId)
     }
 

--- a/ios/CrispChatSdk.swift
+++ b/ios/CrispChatSdk.swift
@@ -75,4 +75,9 @@ class CrispChatSdk: NSObject {
         return true
     }
 
+    @objc
+    static func configure(_ websiteId: String) -> Bool {
+        CrispSDK.configure(websiteID: websiteId)
+    }
+
 }

--- a/plugin/src/withCrispChat.ts
+++ b/plugin/src/withCrispChat.ts
@@ -61,16 +61,14 @@ export function setAppDelegateCall(src: string, websiteId: string) {
     tag: 'react-native-crisp-chat-sdk-call',
     src,
     newSrc: `[CrispSDK configureWithWebsiteID:@"${websiteId}"];`,
-    anchor:
-      /- \(BOOL\)application:\(UIApplication \*\)application didFinishLaunchingWithOptions:\(NSDictionary \*\)launchOptions/,
+    anchor: /- \(BOOL\)application:\(UIApplication \*\)application didFinishLaunchingWithOptions:\(NSDictionary \*\)launchOptions/,
     offset: 2,
     comment: '//',
   });
 }
 
 export function setMainConfiguration(main: string, websiteId: string) {
-  const multiDexApp =
-    /public class MainApplication extends MultiDexApplication implements ReactApplication {/g;
+  const multiDexApp = /public class MainApplication extends MultiDexApplication implements ReactApplication {/g;
   let result = main;
   if (!main.match(multiDexApp)) {
     result = result.replace(
@@ -92,8 +90,7 @@ public class MainApplication extends MultiDexApplication implements ReactApplica
     );
   }
 
-  const cripWebsiteConfig =
-    /Crisp\.configure\(getApplicationContext\(\),"(\w|\d|-)+"\);/g;
+  const cripWebsiteConfig = /Crisp\.configure\(getApplicationContext\(\),"(\w|\d|-)+"\);/g;
   if (!main.match(cripWebsiteConfig)) {
     result = result.replace(
       /super\.onCreate\(\);/,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,6 +27,7 @@ type CrispChatSdkType = {
   pushSessionEvent(name: string, color: CrispSessionEventColors): () => void;
   resetSession(): () => void;
   show(): () => void;
+  configure(websiteId: string): () => void;
 };
 
 const CrispChatSdk = NativeModules.CrispChatSdk as CrispChatSdkType;
@@ -90,4 +91,8 @@ export const resetSession = () => {
 
 export const show = () => {
   CrispChatSdk.show();
+};
+
+export const configure = (websiteId: string) => {
+  CrispChatSdk.configure(websiteId);
 };


### PR DESCRIPTION
The config-plug in expo, even if the `websiteId` parameter was set in `app.json` file was not working to set it for Android version.

```
"expo": {
  {...}
  "plugins":  [
      [
          "react-native-crisp-chat-sdk",
          {
              "websiteId": "MY_WEBSITE_ID"
          }
      ],
  ]
}
```

As a workaround, I added the `configure` function from Crisp, already existing on other SDK, in order to be able to do it manually if needed.