### PR TITLE
fix: update crisp API import

### DIFF
--- a/android/src/main/java/com/reactnativecrispchatsdk/CrispChatSdkModule.kt
+++ b/android/src/main/java/com/reactnativecrispchatsdk/CrispChatSdkModule.kt
@@ -5,10 +5,10 @@ import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
-import im.crisp.client.ChatActivity
-import im.crisp.client.Crisp
-import im.crisp.client.data.SessionEvent
-import im.crisp.client.data.SessionEvent.Color
+import im.crisp.client.external.ChatActivity
+import im.crisp.client.external.Crisp
+import im.crisp.client.external.data.SessionEvent
+import im.crisp.client.external.data.SessionEvent.Color
 
 
 class CrispChatSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {

--- a/plugin/src/__tests__/__snapshots__/withCrispChat-test.ts.snap
+++ b/plugin/src/__tests__/__snapshots__/withCrispChat-test.ts.snap
@@ -712,7 +712,7 @@ import java.util.List;
 
 import androidx.multidex.MultiDexApplication;
 
-import im.crisp.client.Crisp;
+import im.crisp.client.external.Crisp;
       
 public class MainApplication extends MultiDexApplication implements ReactApplication {
       

--- a/plugin/src/withCrispChat.ts
+++ b/plugin/src/withCrispChat.ts
@@ -82,11 +82,11 @@ public class MainApplication extends MultiDexApplication implements ReactApplica
     );
   }
 
-  const cripsImport = /import im.crisp.client.Crisp;/g;
+  const cripsImport = /import im.crisp.client.external.Crisp;/g;
   if (!main.match(cripsImport)) {
     result = result.replace(
       /public class MainApplication extends MultiDexApplication implements ReactApplication {/,
-      `import im.crisp.client.Crisp;
+      `import im.crisp.client.external.Crisp;
       
 public class MainApplication extends MultiDexApplication implements ReactApplication {`
     );


### PR DESCRIPTION
Since `v2.0.4` `crisp-android-sdk` public APi is accessible from `im.crisp.client.external`, updating the import to meet this change.

