### PR TITLE
feat: add support for enabling/disabling Crisp notifications in Android

### DIFF
--- a/plugin/src/__tests__/withCrispChat-test.ts
+++ b/plugin/src/__tests__/withCrispChat-test.ts
@@ -41,16 +41,22 @@ describe(setAppDelegateCall, () => {
 describe(setMainConfiguration, (): void => {
   it('update MainApplication', (): void => {
     expect(
-      setMainConfiguration(defaultMainApplication, 'TEST_WEBSITE_ID')
+      setMainConfiguration(defaultMainApplication, 'TEST_WEBSITE_ID', false)
+    ).toMatchSnapshot();
+  });
+
+  it('update MainApplication with notifications', (): void => {
+    expect(
+      setMainConfiguration(defaultMainApplication, 'TEST_WEBSITE_ID', true)
     ).toMatchSnapshot();
   });
 
   it('update twice leads to same result', (): void => {
     expect(
-      setMainConfiguration(defaultMainApplication, 'TEST_WEBSITE_ID')
+      setMainConfiguration(defaultMainApplication, 'TEST_WEBSITE_ID', false)
     ).toMatch(
       setGradleCrispDependency(
-        setMainConfiguration(defaultMainApplication, 'TEST_WEBSITE_ID'),
+        setMainConfiguration(defaultMainApplication, 'TEST_WEBSITE_ID', false),
         false
       )
     );


### PR DESCRIPTION
This PR explicitly enables Crisp notifications on Android.
Added the call to Crisp.enableNotifications(getApplicationContext(), true) right after Crisp.configure(...) in the setMainConfiguration method of the withCrispChat.ts plugin.
This ensures that when notifications are enabled in the React Native configuration, Crisp properly registers and sends the FCM token.
Multi-websiteId support is not handled at this stage.