### PR TITLE
Chore/upgrade version crisp sdk from 2.0.10 to 2.0.13

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -126,5 +126,5 @@ dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'im.crisp:crisp-sdk:2.0.10'
+  implementation 'im.crisp:crisp-sdk:2.0.13'
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -110,7 +110,7 @@ dependencies {
 
     implementation project(':reactnativecrispchatsdk')
 
-    implementation 'im.crisp:crisp-sdk:2.0.10'
+    implementation 'im.crisp:crisp-sdk:2.0.13'
 
     // Fixes multiDex error
     implementation 'androidx.multidex:multidex:2.0.1'

--- a/plugin/src/__tests__/__snapshots__/withCrispChat-test.ts.snap
+++ b/plugin/src/__tests__/__snapshots__/withCrispChat-test.ts.snap
@@ -602,7 +602,7 @@ android {
 
 dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'im.crisp:crisp-sdk:2.0.10'
+    implementation 'im.crisp:crisp-sdk:2.0.13'
     implementation fileTree(dir: \\"libs\\", include: [\\"*.jar\\"])
 
     //noinspection GradleDynamicVersion

--- a/plugin/src/__tests__/withCrispChat-test.ts
+++ b/plugin/src/__tests__/withCrispChat-test.ts
@@ -41,16 +41,22 @@ describe(setAppDelegateCall, () => {
 describe(setMainConfiguration, (): void => {
   it('update MainApplication', (): void => {
     expect(
-      setMainConfiguration(defaultMainApplication, 'TEST_WEBSITE_ID')
+      setMainConfiguration(defaultMainApplication, 'TEST_WEBSITE_ID', false)
+    ).toMatchSnapshot();
+  });
+
+  it('update MainApplication with notifications', (): void => {
+    expect(
+      setMainConfiguration(defaultMainApplication, 'TEST_WEBSITE_ID', true)
     ).toMatchSnapshot();
   });
 
   it('update twice leads to same result', (): void => {
     expect(
-      setMainConfiguration(defaultMainApplication, 'TEST_WEBSITE_ID')
+      setMainConfiguration(defaultMainApplication, 'TEST_WEBSITE_ID', false)
     ).toMatch(
       setGradleCrispDependency(
-        setMainConfiguration(defaultMainApplication, 'TEST_WEBSITE_ID'),
+        setMainConfiguration(defaultMainApplication, 'TEST_WEBSITE_ID', false),
         false
       )
     );

--- a/plugin/src/withCrispChat.ts
+++ b/plugin/src/withCrispChat.ts
@@ -210,13 +210,13 @@ export function setGradleCrispDependency(
 ) {
   let result = buildGradle;
 
-  const crispDependency = /implementation 'im.crisp:crisp-sdk:2.0.10'/g;
+  const crispDependency = /implementation 'im.crisp:crisp-sdk:2.0.13'/g;
 
   if (!result.match(crispDependency)) {
     result = result.replace(
       /dependencies\s?{/,
       `dependencies {
-    implementation 'im.crisp:crisp-sdk:2.0.10'`
+    implementation 'im.crisp:crisp-sdk:2.0.13'`
     );
   }
 


### PR DESCRIPTION
Bumped Crisp Android SDK from 2.0.10 to 2.0.13.
This update ensures the project uses the latest version of the Crisp SDK for Android, which may include bug fixes, performance improvements, and compatibility updates.
No other code changes were made aside from updating the dependency in build.gradle.