### PR TITLE
chore: update Crisp SDK to version 2.0.13 in Android build files

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -126,5 +126,5 @@ dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'im.crisp:crisp-sdk:2.0.10'
+  implementation 'im.crisp:crisp-sdk:2.0.13'
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -110,7 +110,7 @@ dependencies {
 
     implementation project(':reactnativecrispchatsdk')
 
-    implementation 'im.crisp:crisp-sdk:2.0.10'
+    implementation 'im.crisp:crisp-sdk:2.0.13'
 
     // Fixes multiDex error
     implementation 'androidx.multidex:multidex:2.0.1'

--- a/plugin/src/__tests__/__snapshots__/withCrispChat-test.ts.snap
+++ b/plugin/src/__tests__/__snapshots__/withCrispChat-test.ts.snap
@@ -602,7 +602,7 @@ android {
 
 dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'im.crisp:crisp-sdk:2.0.10'
+    implementation 'im.crisp:crisp-sdk:2.0.13'
     implementation fileTree(dir: \\"libs\\", include: [\\"*.jar\\"])
 
     //noinspection GradleDynamicVersion

--- a/plugin/src/withCrispChat.ts
+++ b/plugin/src/withCrispChat.ts
@@ -192,13 +192,13 @@ export function setGradleCrispDependency(
 ) {
   let result = buildGradle;
 
-  const crispDependency = /implementation 'im.crisp:crisp-sdk:2.0.10'/g;
+  const crispDependency = /implementation 'im.crisp:crisp-sdk:2.0.13'/g;
 
   if (!result.match(crispDependency)) {
     result = result.replace(
       /dependencies\s?{/,
       `dependencies {
-    implementation 'im.crisp:crisp-sdk:2.0.10'`
+    implementation 'im.crisp:crisp-sdk:2.0.13'`
     );
   }
 


### PR DESCRIPTION
Bumped Crisp Android SDK from 2.0.10 to 2.0.13.
This update ensures the project uses the latest version of the Crisp SDK for Android, which may include bug fixes, performance improvements, and compatibility updates.
No other code changes were made aside from updating the dependency in build.gradle.