### PR TITLE
fix: update setSessionBool method to use setBool instead of setString…

### DIFF
--- a/ios/CrispChatSdk.swift
+++ b/ios/CrispChatSdk.swift
@@ -44,7 +44,7 @@ class CrispChatSdk: NSObject {
 
     @objc
     func setSessionBool(_ key: String, value: Bool) {
-        CrispSDK.session.setString(String(value), forKey: key)
+        CrispSDK.session.setBool(value, forKey: key)
     }
 
     @objc


### PR DESCRIPTION
Descritpion : 

Before :  
```
 @objc
    func setSessionBool(_ key: String, value: Bool) {
        CrispSDK.session.setString(String(value), forKey: key)
    }
```

After :
```
@objc
    func setSessionBool(_ key: String, value: Bool) {
        CrispSDK.session.setBool(value, forKey: key)
    }
```