### PR TITLE
fix: remove moduleName method for React Native 0.76 compatibility

### DIFF
--- a/ios/NativeCrispModule.mm
+++ b/ios/NativeCrispModule.mm
@@ -144,9 +144,6 @@ RCT_EXPORT_MODULE(NativeCrispModule)
     [[NativeCrispModuleSwift shared] runBotScenario:scenarioId];
 }
 
-+ (NSString *)moduleName {
-    return @"NativeCrispModule";
-}
 
 #ifdef RCT_NEW_ARCH_ENABLED
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:


### PR DESCRIPTION
**Summary**

Fix IOS build failure (Expo 52.0.46). 

**Main change**

Due to React Native 0.76 using TurboModules in its new architecture, the codegen was automatically creating a duplicate of `moduleName` which caused the ios build to fail because of the method being defined twice (natively and via the codegen).

I removed `moduleName` in the file `NativeCrispModule.mm` and it took care of the issue.

<img width="730" height="198" alt="Screenshot 2025-12-16 at 12 32 53" src="https://github.com/user-attachments/assets/a430def0-d92d-4850-b776-01aacf515cac" />
