### PR TITLE
docs: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # react-native-crisp-chat-sdk
 
+> **:warning: This package is deprecated.**
+>
+> Please use the official [`expo-crisp-sdk`](https://github.com/crisp-im/crisp-sdk-react-native) instead.
+> See the [Migration Guide](https://github.com/crisp-im/crisp-sdk-react-native/blob/master/MIGRATION.md) for step-by-step instructions to upgrade.
+
 React-Native bridge for Crisp chat iOS and Android SDK&#39;s
 
 <img src="./assets/crisp_chat.png" width="375" alt="Crisp screenshot">


### PR DESCRIPTION
## Summary

- Add deprecation banner at the top of the README pointing users to the official [`expo-crisp-sdk`](https://github.com/crisp-im/crisp-sdk-react-native)
- Link to the [Migration Guide](https://github.com/crisp-im/crisp-sdk-react-native/blob/master/MIGRATION.md) for step-by-step upgrade instructions

## Context

The official Crisp React Native SDK is now `expo-crisp-sdk`. This deprecation notice enables npm hard-deprecation of the old package.

## Test plan

- [ ] Verify banner renders correctly on GitHub
- [ ] Verify links resolve correctly